### PR TITLE
Add Experiment Strategy

### DIFF
--- a/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/column_mapping.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/column_mapping.tsv
@@ -31,3 +31,4 @@ file	sha256	hashes	sha256
 file	md5	hashes	md5
 file	size_in_bytes	indexd_scrape	size
 file	data_type	genomic_file	GF_data_type
+file	assay_type	genomic_file	SE_experiment_strategy

--- a/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/table_constants.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/table_constants.tsv
@@ -32,4 +32,3 @@ file	analysis_type
 file	mime_type	
 file	bundle_collection_id_namespace	
 file	bundle_collection_local_id	
-file	assay_type	

--- a/kf_to_c2m2_etl/ingest.py
+++ b/kf_to_c2m2_etl/ingest.py
@@ -143,7 +143,8 @@ class Ingest:
 
 targets = ['participants','diagnoses','studies',
              'biospecimens','biospecimen-diagnoses',
-             'genomic-files','biospecimen-genomic-files']
+             'genomic-files','biospecimen-genomic-files',
+             'sequencing-experiment-genomic-files','sequencing-experiments']
 
 def write_studies_to_disk(studies_dict: dict):
     for index, (study, endpoints) in enumerate(studies_dict.items()):

--- a/kf_to_c2m2_etl/kf_table_combiner.py
+++ b/kf_to_c2m2_etl/kf_table_combiner.py
@@ -19,16 +19,23 @@ foreign_key_mappings = {
         'biospecimen_genomic_file': {'left': 'BS_kf_id', 'right': 'BG_biospecimen_id'}
     },
     'biospecimen_genomic_file': {
-        'genomic_files': {'left': 'BG_genomic_file_id', 'right': 'GF_kf_id'}
+        'genomic_files': {'left': 'BG_genomic_file_id', 'right': 'GF_kf_id'},
+        'sequencing_experiment_genomic_file': {'left': '', 'right': ''}
+    },
+    'genomic_files': {
+        'sequencing_experiment_genomic_file': {'left':'GF_kf_id', 'right':'SG_genomic_file_id'}
+    },
+    'sequencing_experiment_genomic_file': {
+        'sequencing_experiment': {'left': 'SG_sequencing_experiment_id', 'right': 'SE_kf_id'}
     }
 }
 
 kf_tablenames = ['study','participant','biospecimen','biospecimen_genomic_file',
                 # TODO: Using genomic_files is a hack. Find better solution later.
-                 'genomic_files']
+                 'genomic_files','sequencing_experiment_genomic_file','sequencing_experiment']
 
 kf_tables_with_visibility = ['participant','biospecimen','biospecimen_genomic_file',
-                             'genomic_files']
+                             'genomic_files','sequencing_experiment_genomic_file','sequencing_experiment']
 
 # Required due to ingest using endpoint names when ingesting tables
 table_to_endpoint_name = {
@@ -36,7 +43,9 @@ table_to_endpoint_name = {
     'participant': 'participants',
     'biospecimen': 'biospecimens',
     'biospecimen_genomic_file': 'biospecimen-genomic-files',
-    'genomic_files': 'genomic-files'
+    'genomic_files': 'genomic-files',
+    'sequencing_experiment_genomic_file': 'sequencing-experiment-genomic-files',
+    'sequencing_experiment': 'sequencing-experiments'
 }
 
 class KfTableCombiner:


### PR DESCRIPTION
This branch adds back in the transformation of experiment strategy to assay type after resolution of multiple experiment strategies per genomic file was resolved by DataOps.

At first glance, the change looks good but there is a lower file count between test submission and last good submission. This still must be resolved prior to the merging of this pull request.