### PR TITLE
TPM-350 Resolve Biosample and Subject Disease Validation Failures

### DIFF
--- a/kf_to_c2m2_etl/fhir_transform.py
+++ b/kf_to_c2m2_etl/fhir_transform.py
@@ -120,7 +120,7 @@ def convert_fhir_to_subject_disease(the_df: pd.DataFrame):
                           left_on='meta_tag_0_code',
                           right_on='study_id')
     # There is not disease mapping for the following study
-    the_df.drop(the_df.query('identifier_0_value == "SD_DZ4GPQX6"').index,inplace=True)
+    the_df.drop(the_df.query('meta_tag_0_code == "SD_DZ4GPQX6"').index,inplace=True)
 
     return the_df
 
@@ -132,7 +132,7 @@ def convert_fhir_to_biosample_disease(the_df: pd.DataFrame):
                           left_on='meta_tag_0_code',
                           right_on='study_id')
     # There is not disease mapping for the following study
-    the_df.drop(the_df.query('identifier_0_value == "SD_DZ4GPQX6"').index,inplace=True)
+    the_df.drop(the_df.query('meta_tag_0_code == "SD_DZ4GPQX6"').index,inplace=True)
 
     return the_df
 

--- a/kf_to_c2m2_etl/fhir_transform.py
+++ b/kf_to_c2m2_etl/fhir_transform.py
@@ -119,6 +119,9 @@ def convert_fhir_to_subject_disease(the_df: pd.DataFrame):
                           how='inner',
                           left_on='meta_tag_0_code',
                           right_on='study_id')
+    # There is not disease mapping for the following study
+    the_df.drop(the_df.query('identifier_0_value == "SD_DZ4GPQX6"').index,inplace=True)
+
     return the_df
 
 @convert_fhir_to_c2m2
@@ -128,6 +131,9 @@ def convert_fhir_to_biosample_disease(the_df: pd.DataFrame):
                           how='inner',
                           left_on='meta_tag_0_code',
                           right_on='study_id')
+    # There is not disease mapping for the following study
+    the_df.drop(the_df.query('identifier_0_value == "SD_DZ4GPQX6"').index,inplace=True)
+
     return the_df
 
 @convert_fhir_to_c2m2

--- a/kf_to_c2m2_etl/fhir_transform.py
+++ b/kf_to_c2m2_etl/fhir_transform.py
@@ -112,27 +112,34 @@ def convert_fhir_to_biosample_from_subject(the_df: pd.DataFrame):
         the_df[age_at_even_days_col_name] = None
     return the_df
 
+def remove_studies_without_disease_mapping(the_df: pd.DataFrame):
+    disease_mapping_df = pd.read_table(os.path.join(file_locations.get_ontology_mappings_path(),'project_disease_matrix_only.tsv'))
+    no_disease_df = disease_mapping_df.loc[(disease_mapping_df['DOID'] == 'NA') | (disease_mapping_df['DOID'].isna())]
+    return the_df[~the_df['meta_tag_0_code'].isin(no_disease_df['study_id'])]
+
 @convert_fhir_to_c2m2
 def convert_fhir_to_subject_disease(the_df: pd.DataFrame):
     project_disease_df = pd.read_table(os.path.join(file_locations.get_ontology_mappings_path(),'project_disease_matrix_only.tsv'))
+
     the_df = the_df.merge(project_disease_df,
                           how='inner',
                           left_on='meta_tag_0_code',
                           right_on='study_id')
-    # There is not disease mapping for the following study
-    the_df.drop(the_df.query('meta_tag_0_code == "SD_DZ4GPQX6"').index,inplace=True)
+
+    the_df = remove_studies_without_disease_mapping(the_df)
 
     return the_df
 
 @convert_fhir_to_c2m2
 def convert_fhir_to_biosample_disease(the_df: pd.DataFrame):
     project_disease_df = pd.read_table(os.path.join(file_locations.get_ontology_mappings_path(),'project_disease_matrix_only.tsv'))
+
     the_df = the_df.merge(project_disease_df,
                           how='inner',
                           left_on='meta_tag_0_code',
                           right_on='study_id')
-    # There is not disease mapping for the following study
-    the_df.drop(the_df.query('meta_tag_0_code == "SD_DZ4GPQX6"').index,inplace=True)
+
+    the_df = remove_studies_without_disease_mapping(the_df)
 
     return the_df
 

--- a/validate_submission.sh
+++ b/validate_submission.sh
@@ -2,5 +2,5 @@
 cd frictionless_validation
 
 # Generates the validation report 
-frictionless validate C2M2_datapackage.json > "../frictionlessreport_c2m2_submission_$1_$2_$3.txt"
+frictionless validate --limit-memory 10000 C2M2_datapackage.json > "../frictionlessreport_c2m2_submission_$1_$2_$3.txt"
  


### PR DESCRIPTION
In the ETL transform layer, the disease mappings are applied to studies with relevant disease mappings, however studies without an associated disease mapping should be omitted from this operation.

This PR will attempt to remove those studies without disease mappings from the transform layer's disease mapping operation.