### PR TITLE
AD-2725: Improve File Format Mapping Completeness

### DIFF
--- a/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
@@ -7,7 +7,7 @@ format:3327	bai
 format:3914	bait_bias_detail_metrics
 format:3914	bait_bias_summary_metrics
 format:2572	bam
-	cns
+format:2012	cns
 	crai
 format:3462	cram
 	csv

--- a/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
@@ -22,7 +22,7 @@ format:2331	html
 format:3578	idat
 format:3914	insert_size_metrics
 format:3008	maf
-	ndjson
+format:3464	ndjson
 format:3508	pdf
 	ped
 format:3914	pre_adapter_detail_metrics

--- a/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
@@ -35,7 +35,7 @@ format:3914	summary_metrics
 	svs
 format:3914	table
 	tar
-	tbi
+format:3616	tbi
 format:3475	tsv
 	txt
 format:3914	variant_calling_detail_metrics

--- a/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
@@ -29,7 +29,7 @@ format:3914	pre_adapter_detail_metrics
 format:3914	pre_adapter_summary_metrics
 format:3603	png
 	results
-	seg
+format:2012	seg
 format:3914	summary_metrics
 	svs
 	tar

--- a/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
@@ -33,6 +33,7 @@ format:2012	seg
 format:3914	selfSM
 format:3914	summary_metrics
 	svs
+format:3914	table
 	tar
 	tbi
 format:3475	tsv

--- a/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
@@ -24,7 +24,7 @@ format:3914	insert_size_metrics
 format:3008	maf
 format:3464	ndjson
 format:3508	pdf
-	ped
+format:3286	ped
 format:3914	pre_adapter_detail_metrics
 format:3914	pre_adapter_summary_metrics
 format:3603	png

--- a/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
@@ -35,7 +35,7 @@ format:3914	summary_metrics
 	svs
 format:3914	table
 	tar
-format:3616	tbi
+format:3700	tbi
 format:3475	tsv
 	txt
 format:3914	variant_calling_detail_metrics

--- a/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
@@ -30,6 +30,7 @@ format:3914	pre_adapter_summary_metrics
 format:3603	png
 	results
 format:2012	seg
+format:3914	selfSM
 format:3914	summary_metrics
 	svs
 	tar

--- a/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/ontology_mappings/file_format.tsv
@@ -1,28 +1,42 @@
 id	name
 	Not Reported
 	Other
+format:3914	alignment_summary_metrics
+format:3914	alignmentsummary_metrics
 format:3327	bai
+format:3914	bait_bias_detail_metrics
+format:3914	bait_bias_summary_metrics
 format:2572	bam
 	cns
 	crai
 format:3462	cram
 	csv
 	dcm
+format:3914	detail_metrics
+format:3914	error_summary_metrics
 format:1930	fastq
 format:3829	gpr
 	gvcf
+format:3914	hs_metrics
 format:2331	html
 format:3578	idat
+format:3914	insert_size_metrics
 format:3008	maf
 	ndjson
 format:3508	pdf
 	ped
+format:3914	pre_adapter_detail_metrics
+format:3914	pre_adapter_summary_metrics
 format:3603	png
 	results
 	seg
+format:3914	summary_metrics
 	svs
 	tar
 	tbi
 format:3475	tsv
 	txt
+format:3914	variant_calling_detail_metrics
+format:3914	variant_calling_summary_metrics
 format:3016	vcf
+format:3914	wgs_metrics


### PR DESCRIPTION
Improves the mapping coverage for File Format types, including but not limited to `.tbi`, `.cns`, `.table`, `.seg`, `.selfSM`, `.ped`, and `.ndjson`.