### PR TITLE
AD-3825: Updates to `persistent_id` and addition of `access_url` fields in `file` table

### DIFF
--- a/.idea/c2m2-submission-process.iml
+++ b/.idea/c2m2-submission-process.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (c2m2-submission-process)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="372fa0eb-5d0c-4076-8c6b-bfe774cced89" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/kf_to_c2m2_etl/conversion_tables/fhir/file.tsv" beforeDir="false" afterPath="$PROJECT_DIR$/kf_to_c2m2_etl/conversion_tables/fhir/file.tsv" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/kf_to_c2m2_etl/value_converter.py" beforeDir="false" afterPath="$PROJECT_DIR$/kf_to_c2m2_etl/value_converter.py" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2qJf4eOnLjoySnG9dWg1ZTtiYtn" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;
+  }
+}</component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="372fa0eb-5d0c-4076-8c6b-bfe774cced89" name="Changes" comment="" />
+      <created>1734385408923</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1734385408923</updated>
+    </task>
+    <servers />
+  </component>
+</project>

--- a/kf_to_c2m2_etl/conversion_tables/fhir/file.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/fhir/file.tsv
@@ -1,7 +1,7 @@
 FHIR Resource	FHIR Field	C2M2 Entity	C2M2 Field
 DocumentReference	identifier_0_value	file	local_id
 DocumentReference	meta_tag_0_code	file	project_local_id
-DocumentReference	content_0_attachment_url	file	persistent_id
+DocumentReference	content_0_attachment_url	file	access_url
 DocumentReference	content_0_attachment_extension_0_valueDecimal	file	size_in_bytes
 DocumentReference	content_0_attachment_extension_2_valueCodeableConcept_text	file	sha256
 DocumentReference	content_0_attachment_extension_1_valueCodeableConcept_text	file	md5

--- a/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/ds_table_constants.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/ds_table_constants.tsv
@@ -38,5 +38,5 @@ file	mime_type
 file	bundle_collection_id_namespace	
 file	bundle_collection_local_id	
 file	creation_time	
-file  persistent_id  
+file	persistent_id	
 file	uncompressed_size_in_bytes	

--- a/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/ds_table_constants.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/ds_table_constants.tsv
@@ -38,4 +38,5 @@ file	mime_type
 file	bundle_collection_id_namespace	
 file	bundle_collection_local_id	
 file	creation_time	
+file  persistent_id  
 file	uncompressed_size_in_bytes	

--- a/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/fhir_table_constants.tsv
+++ b/kf_to_c2m2_etl/conversion_tables/kf_to_c2m2_mappings/fhir_table_constants.tsv
@@ -38,4 +38,5 @@ file	mime_type
 file	bundle_collection_id_namespace	
 file	bundle_collection_local_id	
 file	creation_time	
+file	persistent_id	
 file	uncompressed_size_in_bytes	

--- a/kf_to_c2m2_etl/fhir_transform.py
+++ b/kf_to_c2m2_etl/fhir_transform.py
@@ -162,7 +162,7 @@ def update_hash(row):
     else:
         return row['DocumentReference_content_0_attachment_extension_1_valueCodeableConcept_text']
 
-def update_persistent_id(row):
+def update_access_url(row):
     if row['DocumentReference_content_0_attachment_extension_1_valueCodeableConcept_coding_0_display'] == 'etag':
         return np.nan
     else:

--- a/kf_to_c2m2_etl/transform.py
+++ b/kf_to_c2m2_etl/transform.py
@@ -9,7 +9,7 @@ from file_locations import file_locations
 from kf_table_combiner import KfTableCombiner
 from etl_types import ETLType
 
-from value_converter import modify_dbgap, get_persistent_id, \
+from value_converter import modify_dbgap, get_access_url, \
                             path_to_filename, convert_days_to_years, \
                             apply_uberon_mapping
 
@@ -211,8 +211,8 @@ def convert_kf_to_file(kf_genomic_files):
     file_df = kf_to_cfde_value_converter(ETLType.DS, file_df,'SE_experiment_strategy')
     
     file_df['BS_dbgap_consent_code'] = file_df['BS_dbgap_consent_code'].apply(modify_dbgap)
-    file_df['persistent_id'] = file_df.apply(lambda the_df: 
-                                             get_persistent_id(the_df['PT_study_id'],
+    file_df['access_url'] = file_df.apply(lambda the_df: 
+                                             get_access_url(the_df['PT_study_id'],
                                                                the_df['GF_latest_did'],
                                                                the_df['md5']),
                                              axis=1)

--- a/kf_to_c2m2_etl/value_converter.py
+++ b/kf_to_c2m2_etl/value_converter.py
@@ -14,7 +14,7 @@ def modify_dbgap(study_id):
         else:
             return ''
 
-def get_persistent_id(study, did, md5):
+def get_access_url(study, did, md5):
     if isinstance(study,str) and isinstance(did,str) and pd.notnull(md5):
         if study not in ['SD_BHJXBDQK','SD_8Y99QZJJ','SD_46RR9ZR6','SD_YNSSAPHE']:
             return 'drs://data.kidsfirstdrc.org/' + did


### PR DESCRIPTION
The latest C2M2 schema changes the usage of the `persistent_id` field and adds a new `access_url` field. These changes now make `persistent_id` into a blank constant field and move the previous data from the `persistent_id` field into the new `access_url` field.